### PR TITLE
Fix broken print

### DIFF
--- a/src/deps_infer/main.clj
+++ b/src/deps_infer/main.clj
@@ -89,5 +89,4 @@
                             (sorted-map)
                             grouped)]
         (doseq [[k v] results]
-          (prn k v))))))
           (prn (path->org k) v))))))


### PR DESCRIPTION
The previous fix did not remove the old print. Sorry about that. `main.clj` was not compiling.