### PR TITLE
Add warn when multiple different artifacts provide the same namespace

### DIFF
--- a/src/deps_infer/main.clj
+++ b/src/deps_infer/main.clj
@@ -79,7 +79,13 @@
                                             (:namespace-usages analysis)))
                 entries (reduce (fn [acc [n lang]]
                                   (if-let [dep-entries (get index n)]
-                                    (let [dep-entries (select-deps lang dep-entries)]
+                                    (let [dep-entries (select-deps lang dep-entries)
+                                          artifacts (distinct (map (juxt :group-id :artifact) dep-entries))]
+                                      (when (> (count artifacts) 1)
+                                        (binding [*out* *err*]
+                                          (println "WARNING:" n "has multiple providers:")
+                                          (doseq [[g a] artifacts]
+                                            (println "*" (str (str/replace g #"[/]" ".") "/" a)))))
                                       (into acc dep-entries))
                                     (do
                                       (when-not (contains? defined-namespaces n)


### PR DESCRIPTION
Sample output from this project with `seancorfield/depstar {:mvn/version "0.1.6"}` on `.m2`:
```
$ clojure -M -m deps-infer.main
WARNING: clojure.edn has multiple providers:
* seancorfield/depstar
* org.clojure/clojure
WARNING: clojure.java.io has multiple providers:
* seancorfield/depstar
* org.clojure/clojure
WARNING: clojure.pprint has multiple providers:
* seancorfield/depstar
* org.clojure/clojure
WARNING: clojure.string has multiple providers:
* seancorfield/depstar
* org.clojure/clojure
babashka/fs {:mvn/version "0.0.5"}
clj-kondo/clj-kondo {:mvn/version "2021.09.15"}
org.clojure/clojure {:mvn/version "1.11.0-alpha1"}
org.clojure/tools.cli {:mvn/version "1.0.206"}
seancorfield/depstar {:mvn/version "0.1.6"}
version-clj/version-clj {:mvn/version "2.0.1"}
```